### PR TITLE
Fix missing #app element

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -2,25 +2,32 @@ import './style.css'
 import javascriptLogo from './javascript.svg'
 import viteLogo from '/vite.svg'
 import { setupCounter } from './counter.js'
-import 'bootstrap/dist/css/bootstrap.min.css';
-import 'bootstrap/dist/js/bootstrap.bundle.min.js';
+import 'bootstrap/dist/css/bootstrap.min.css'
+import 'bootstrap/dist/js/bootstrap.bundle.min.js'
 
-document.querySelector('#app').innerHTML = `
-  <div>
-    <a href="https://vite.dev" target="_blank">
-      <img src="${viteLogo}" class="logo" alt="Vite logo" />
-    </a>
-    <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript" target="_blank">
-      <img src="${javascriptLogo}" class="logo vanilla" alt="JavaScript logo" />
-    </a>
-    <h1>Hello Vite!</h1>
-    <div class="card">
-      <button id="counter" type="button"></button>
+// This demo code only runs on pages that include a `#app` element.
+const app = document.querySelector('#app')
+if (app) {
+  app.innerHTML = `
+    <div>
+      <a href="https://vite.dev" target="_blank">
+        <img src="${viteLogo}" class="logo" alt="Vite logo" />
+      </a>
+      <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript" target="_blank">
+        <img src="${javascriptLogo}" class="logo vanilla" alt="JavaScript logo" />
+      </a>
+      <h1>Hello Vite!</h1>
+      <div class="card">
+        <button id="counter" type="button"></button>
+      </div>
+      <p class="read-the-docs">
+        Click on the Vite logo to learn more
+      </p>
     </div>
-    <p class="read-the-docs">
-      Click on the Vite logo to learn more
-    </p>
-  </div>
-`
+  `
 
-setupCounter(document.querySelector('#counter'))
+  const counterBtn = document.querySelector('#counter')
+  if (counterBtn) {
+    setupCounter(counterBtn)
+  }
+}


### PR DESCRIPTION
## Summary
- guard the demo script so it only runs when an `#app` element exists

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68404d3e3fb4833281a27eb630659c35